### PR TITLE
feat(stats): add real-time container stats with CPU, memory, and PIDs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,10 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Toaster } from "sonner";
-import { ThemeProvider } from "./contexts/ThemeContext";
-import { AppLayout } from "./components/layout/AppLayout";
-import { ProjectsPage } from "./pages/ProjectsPage";
-import { ProjectDetailPage } from "./pages/ProjectDetailPage";
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'sonner';
+import { ThemeProvider } from './contexts/ThemeContext';
+import { AppLayout } from './components/layout/AppLayout';
+import { ProjectsPage } from './pages/ProjectsPage';
+import { ProjectDetailPage } from './pages/ProjectDetailPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,7 +25,10 @@ function App() {
             <Routes>
               <Route path="/" element={<Navigate to="/projects" replace />} />
               <Route path="/projects" element={<ProjectsPage />} />
-              <Route path="/projects/:projectId" element={<ProjectDetailPage />} />
+              <Route
+                path="/projects/:projectId"
+                element={<ProjectDetailPage />}
+              />
             </Routes>
           </AppLayout>
         </BrowserRouter>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,11 +1,21 @@
-import type { Project, Container, CreateProjectRequest, ValidatePathResponse, APIResponse } from './types';
+import type {
+  Project,
+  Container,
+  CreateProjectRequest,
+  ValidatePathResponse,
+  APIResponse,
+  ContainerStats,
+} from "./types";
 
-const API_BASE = '/api';
+const API_BASE = "/api";
 
-async function apiClient<T>(endpoint: string, options?: RequestInit): Promise<T> {
+async function apiClient<T>(
+  endpoint: string,
+  options?: RequestInit,
+): Promise<T> {
   const response = await fetch(`${API_BASE}${endpoint}`, {
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     },
     ...options,
   });
@@ -17,36 +27,40 @@ async function apiClient<T>(endpoint: string, options?: RequestInit): Promise<T>
   }
 
   if (data.data === null) {
-    throw new Error('No data returned');
+    throw new Error("No data returned");
   }
 
   return data.data;
 }
 
 export async function listProjects(): Promise<Project[]> {
-  return apiClient<Project[]>('/projects');
+  return apiClient<Project[]>("/projects");
 }
 
 export async function getProject(id: string): Promise<Project> {
   return apiClient<Project>(`/projects/${id}`);
 }
 
-export async function createProject(request: CreateProjectRequest): Promise<Project> {
-  return apiClient<Project>('/projects', {
-    method: 'POST',
+export async function createProject(
+  request: CreateProjectRequest,
+): Promise<Project> {
+  return apiClient<Project>("/projects", {
+    method: "POST",
     body: JSON.stringify(request),
   });
 }
 
 export async function deleteProject(id: string): Promise<void> {
   await apiClient<void>(`/projects/${id}`, {
-    method: 'DELETE',
+    method: "DELETE",
   });
 }
 
-export async function validatePath(path: string): Promise<ValidatePathResponse> {
-  return apiClient<ValidatePathResponse>('/projects/validate', {
-    method: 'POST',
+export async function validatePath(
+  path: string,
+): Promise<ValidatePathResponse> {
+  return apiClient<ValidatePathResponse>("/projects/validate", {
+    method: "POST",
     body: JSON.stringify({ path }),
   });
 }
@@ -57,18 +71,22 @@ export async function getContainers(projectId: string): Promise<Container[]> {
 
 export async function startContainer(id: string): Promise<void> {
   await apiClient<void>(`/containers/${id}/start`, {
-    method: 'POST',
+    method: "POST",
   });
 }
 
 export async function stopContainer(id: string): Promise<void> {
   await apiClient<void>(`/containers/${id}/stop`, {
-    method: 'POST',
+    method: "POST",
   });
 }
 
 export async function restartContainer(id: string): Promise<void> {
   await apiClient<void>(`/containers/${id}/restart`, {
-    method: 'POST',
+    method: "POST",
   });
+}
+
+export async function getContainerStats(id: string): Promise<ContainerStats> {
+  return apiClient<ContainerStats>(`/containers/${id}/stats`);
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -47,3 +47,9 @@ export interface APIResponse<T> {
     message: string;
   } | null;
 }
+
+export interface ContainerStats {
+  cpu_percentage: number;
+  memory_percentage: number;
+  pids: number;
+}

--- a/frontend/src/components/AddProjectModal.tsx
+++ b/frontend/src/components/AddProjectModal.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Check, AlertCircle } from 'lucide-react';
+import { useState, useEffect } from "react";
+import { Check, AlertCircle } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -7,10 +7,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from './ui/dialog';
-import { Input } from './ui/input';
-import { Label } from './ui/label';
-import { Button } from './ui/button';
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { Button } from "./ui/button";
 
 interface AddProjectModalProps {
   isOpen: boolean;
@@ -25,53 +25,53 @@ export function AddProjectModal({
   onSubmit,
   isSubmitting,
 }: AddProjectModalProps) {
-  const [path, setPath] = useState('');
+  const [path, setPath] = useState("");
   const [validationState, setValidationState] = useState<{
-    status: 'idle' | 'validating' | 'valid' | 'invalid';
+    status: "idle" | "validating" | "valid" | "invalid";
     message: string;
     composeFile?: string;
-  }>({ status: 'idle', message: '' });
+  }>({ status: "idle", message: "" });
 
   useEffect(() => {
     if (isOpen) {
-      setPath('');
-      setValidationState({ status: 'idle', message: '' });
+      setPath("");
+      setValidationState({ status: "idle", message: "" });
     }
   }, [isOpen]);
 
   useEffect(() => {
     if (!path.trim()) {
-      setValidationState({ status: 'idle', message: '' });
+      setValidationState({ status: "idle", message: "" });
       return;
     }
 
-    setValidationState({ status: 'validating', message: 'Checking...' });
+    setValidationState({ status: "validating", message: "Checking..." });
 
     const timer = setTimeout(async () => {
       try {
-        const response = await fetch('/api/projects/validate', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+        const response = await fetch("/api/projects/validate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ path }),
         });
         const data = await response.json();
 
         if (data.data?.valid) {
           setValidationState({
-            status: 'valid',
+            status: "valid",
             message: `Detected: ${data.data.compose_file}`,
             composeFile: data.data.compose_file,
           });
         } else {
           setValidationState({
-            status: 'invalid',
-            message: data.data?.error || 'Validation failed',
+            status: "invalid",
+            message: data.data?.error || "Validation failed",
           });
         }
       } catch {
         setValidationState({
-          status: 'invalid',
-          message: 'Validation failed',
+          status: "invalid",
+          message: "Validation failed",
         });
       }
     }, 500);
@@ -81,7 +81,7 @@ export function AddProjectModal({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (validationState.status === 'valid' && !isSubmitting) {
+    if (validationState.status === "valid" && !isSubmitting) {
       onSubmit(path);
     }
   };
@@ -93,7 +93,8 @@ export function AddProjectModal({
           <DialogHeader>
             <DialogTitle>Add Project</DialogTitle>
             <DialogDescription>
-              Enter the directory containing your docker-compose.yml or compose.yaml file
+              Enter the directory containing your docker-compose.yml or
+              compose.yaml file
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
@@ -115,17 +116,17 @@ export function AddProjectModal({
             {validationState.message && (
               <div
                 className={`flex items-center gap-2 text-sm ${
-                  validationState.status === 'valid'
-                    ? 'text-green-600 dark:text-green-400'
-                    : validationState.status === 'invalid'
-                      ? 'text-red-600 dark:text-red-400'
-                      : 'text-muted-foreground'
+                  validationState.status === "valid"
+                    ? "text-green-600 dark:text-green-400"
+                    : validationState.status === "invalid"
+                      ? "text-red-600 dark:text-red-400"
+                      : "text-muted-foreground"
                 }`}
               >
-                {validationState.status === 'valid' && (
+                {validationState.status === "valid" && (
                   <Check className="w-4 h-4" />
                 )}
-                {validationState.status === 'invalid' && (
+                {validationState.status === "invalid" && (
                   <AlertCircle className="w-4 h-4" />
                 )}
                 <span>{validationState.message}</span>
@@ -143,9 +144,9 @@ export function AddProjectModal({
             </Button>
             <Button
               type="submit"
-              disabled={validationState.status !== 'valid' || isSubmitting}
+              disabled={validationState.status !== "valid" || isSubmitting}
             >
-              {isSubmitting ? 'Adding...' : 'Add Project'}
+              {isSubmitting ? "Adding..." : "Add Project"}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard.tsx
@@ -1,9 +1,9 @@
-import { Link } from 'react-router';
-import { Trash2 } from 'lucide-react';
-import type { Project } from '../api/types';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
-import { Badge } from './ui/badge';
-import { Button } from './ui/button';
+import { Link } from "react-router";
+import { Trash2 } from "lucide-react";
+import type { Project } from "../api/types";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
 
 interface ProjectCardProps {
   project: Project;

--- a/frontend/src/components/containers/ContainerStatsCell.tsx
+++ b/frontend/src/components/containers/ContainerStatsCell.tsx
@@ -1,0 +1,49 @@
+import type { ContainerStats } from "@/api/types";
+import { useContainerStats } from "@/hooks/useContainerStats";
+
+interface ContainerStatsCellProps {
+  containerId: string;
+}
+
+interface StatsCellProps {
+  containerId: string;
+  renderValue: (stats: ContainerStats) => string | number;
+}
+
+function formatPercentage(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function StatsCell({ containerId, renderValue }: StatsCellProps) {
+  const { data: stats, isLoading } = useContainerStats(containerId);
+
+  if (isLoading || !stats) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+
+  return <span className="text-muted-foreground">{renderValue(stats)}</span>;
+}
+
+export function ContainerStatsCell({ containerId }: ContainerStatsCellProps) {
+  return (
+    <StatsCell
+      containerId={containerId}
+      renderValue={stats => formatPercentage(stats.cpu_percentage)}
+    />
+  );
+}
+
+export function ContainerMemoryCell({ containerId }: ContainerStatsCellProps) {
+  return (
+    <StatsCell
+      containerId={containerId}
+      renderValue={stats => formatPercentage(stats.memory_percentage)}
+    />
+  );
+}
+
+export function ContainerPIDsCell({ containerId }: ContainerStatsCellProps) {
+  return (
+    <StatsCell containerId={containerId} renderValue={stats => stats.pids} />
+  );
+}

--- a/frontend/src/components/containers/ContainerTable.tsx
+++ b/frontend/src/components/containers/ContainerTable.tsx
@@ -1,5 +1,5 @@
-import { Play, Square, RotateCw } from 'lucide-react';
-import type { Container } from '../../api/types';
+import { Play, Square, RotateCw } from "lucide-react";
+import type { Container } from "../../api/types";
 import {
   Table,
   TableBody,
@@ -7,9 +7,14 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '../ui/table';
-import { Badge } from '../ui/badge';
-import { Button } from '../ui/button';
+} from "../ui/table";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import {
+  ContainerStatsCell,
+  ContainerMemoryCell,
+  ContainerPIDsCell,
+} from "./ContainerStatsCell";
 
 interface ContainerTableProps {
   containers: Container[];
@@ -22,39 +27,39 @@ interface ContainerTableProps {
 function StatusDot({ state }: { state: string }) {
   const getStatusColor = () => {
     switch (state) {
-      case 'running':
-        return 'bg-emerald-500';
-      case 'paused':
-        return 'bg-amber-500';
-      case 'exited':
-      case 'dead':
-        return 'bg-slate-500';
+      case "running":
+        return "bg-emerald-500";
+      case "paused":
+        return "bg-amber-500";
+      case "exited":
+      case "dead":
+        return "bg-slate-500";
       default:
-        return 'bg-red-500';
+        return "bg-red-500";
     }
   };
 
   return <div className={`w-2 h-2 rounded-full ${getStatusColor()}`} />;
 }
 
-function getStateBadgeVariant(state: string): 'success' | 'warning' | 'muted' {
+function getStateBadgeVariant(state: string): "success" | "warning" | "muted" {
   switch (state) {
-    case 'running':
-      return 'success';
-    case 'paused':
-      return 'warning';
-    case 'exited':
-    case 'dead':
-      return 'muted';
+    case "running":
+      return "success";
+    case "paused":
+      return "warning";
+    case "exited":
+    case "dead":
+      return "muted";
     default:
-      return 'muted';
+      return "muted";
   }
 }
 
-function formatPorts(ports: Container['ports']): string {
-  if (ports.length === 0) return '-';
+function formatPorts(ports: Container["ports"]): string {
+  if (ports.length === 0) return "-";
 
-  return ports.map(p => `${p.host}:${p.container}`).join(', ');
+  return ports.map((p) => `${p.host}:${p.container}`).join(", ");
 }
 
 export function ContainerTable({
@@ -83,12 +88,15 @@ export function ContainerTable({
           <TableHead>Name</TableHead>
           <TableHead>Image</TableHead>
           <TableHead>Ports</TableHead>
+          <TableHead>CPU %</TableHead>
+          <TableHead>Memory %</TableHead>
+          <TableHead>PIDs</TableHead>
           <TableHead>State</TableHead>
           <TableHead>Actions</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {containers.map(container => (
+        {containers.map((container) => (
           <TableRow key={container.id}>
             <TableCell>
               <StatusDot state={container.state} />
@@ -101,6 +109,15 @@ export function ContainerTable({
             <TableCell className="text-sm text-muted-foreground">
               {formatPorts(container.ports)}
             </TableCell>
+            <TableCell className="text-sm">
+              <ContainerStatsCell containerId={container.id} />
+            </TableCell>
+            <TableCell className="text-sm">
+              <ContainerMemoryCell containerId={container.id} />
+            </TableCell>
+            <TableCell className="text-sm">
+              <ContainerPIDsCell containerId={container.id} />
+            </TableCell>
             <TableCell>
               <Badge variant={getStateBadgeVariant(container.state)}>
                 {container.state}
@@ -108,7 +125,7 @@ export function ContainerTable({
             </TableCell>
             <TableCell>
               <div className="flex items-center gap-1">
-                {container.state === 'running' ? (
+                {container.state === "running" ? (
                   <>
                     <Button
                       variant="ghost"

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -1,12 +1,12 @@
-import { Sun, Moon, Monitor } from 'lucide-react';
-import { useThemeToggle } from '../../contexts/ThemeContext';
-import { Button } from '../ui/button';
-import { Link } from 'react-router';
+import { Sun, Moon, Monitor } from "lucide-react";
+import { useThemeToggle } from "../../contexts/ThemeContext";
+import { Button } from "../ui/button";
+import { Link } from "react-router";
 
 export function AppHeader() {
   const { theme, toggleTheme } = useThemeToggle();
 
-  const ThemeIcon = theme === 'light' ? Sun : theme === 'dark' ? Moon : Monitor;
+  const ThemeIcon = theme === "light" ? Sun : theme === "dark" ? Moon : Monitor;
 
   return (
     <header className="flex items-center justify-between px-4 border-b h-14 bg-card border-border">

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,22 +1,18 @@
-import type { ReactNode } from 'react';
-import { AppHeader } from './AppHeader';
-import { AppSidebar } from './AppSidebar';
+import type { ReactNode } from "react";
+import { AppHeader } from "./AppHeader";
+import { AppSidebar } from "./AppSidebar";
 
 interface AppLayoutProps {
   children: ReactNode;
 }
 
-export function AppLayout({
-  children,
-}: AppLayoutProps) {
+export function AppLayout({ children }: AppLayoutProps) {
   return (
     <div className="flex flex-col h-screen bg-background">
       <AppHeader />
       <div className="flex flex-1 overflow-hidden">
         <AppSidebar />
-        <main className="flex-1 overflow-y-auto">
-          {children}
-        </main>
+        <main className="flex-1 overflow-y-auto">{children}</main>
       </div>
     </div>
   );

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react';
-import { NavLink } from 'react-router';
+import { useState } from "react";
+import { NavLink } from "react-router";
 import {
   FolderOpen,
   FolderClosed,
   ChevronLeft,
   ChevronRight,
-} from 'lucide-react';
-import { useProjects } from '../../hooks/useProjects';
-import { Button } from '../ui/button';
-import type { Project } from '../../api/types';
+} from "lucide-react";
+import { useProjects } from "../../hooks/useProjects";
+import { Button } from "../ui/button";
+import type { Project } from "../../api/types";
 
 export function AppSidebar() {
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -17,7 +17,7 @@ export function AppSidebar() {
   return (
     <aside
       className={`flex flex-col h-full bg-card border-r border-border transition-all duration-300 ${
-        isCollapsed ? 'w-16' : 'w-64'
+        isCollapsed ? "w-16" : "w-64"
       }`}
     >
       <div className="flex items-center justify-between p-3 border-b border-border">
@@ -40,9 +40,9 @@ export function AppSidebar() {
       <nav className="flex-1 p-2 overflow-y-auto">
         {isLoading ? (
           <div
-            className={`text-sm text-muted-foreground ${isCollapsed ? 'text-center' : 'px-3 py-2'}`}
+            className={`text-sm text-muted-foreground ${isCollapsed ? "text-center" : "px-3 py-2"}`}
           >
-            {isCollapsed ? '...' : 'Loading...'}
+            {isCollapsed ? "..." : "Loading..."}
           </div>
         ) : projects && projects.length > 0 ? (
           <ul className="space-y-1">
@@ -53,9 +53,9 @@ export function AppSidebar() {
                   className={({ isActive }) =>
                     `flex items-center gap-2 w-full px-3 py-2 text-sm rounded-md transition-colors ${
                       isActive
-                        ? 'bg-accent text-accent-foreground'
-                        : 'text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground'
-                    } ${isCollapsed ? 'justify-center px-0' : ''}`
+                        ? "bg-accent text-accent-foreground"
+                        : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground"
+                    } ${isCollapsed ? "justify-center px-0" : ""}`
                   }
                   title={isCollapsed ? project.name : undefined}
                 >
@@ -77,9 +77,9 @@ export function AppSidebar() {
           </ul>
         ) : (
           <div
-            className={`text-sm text-muted-foreground ${isCollapsed ? 'text-center' : 'px-3 py-2'}`}
+            className={`text-sm text-muted-foreground ${isCollapsed ? "text-center" : "px-3 py-2"}`}
           >
-            {isCollapsed ? '—' : 'No projects'}
+            {isCollapsed ? "—" : "No projects"}
           </div>
         )}
       </nav>

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,13 +1,13 @@
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
 
-const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialog = AlertDialogPrimitive.Root;
 
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = AlertDialogPrimitive.Portal
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
@@ -16,13 +16,13 @@ const AlertDialogOverlay = React.forwardRef<
   <AlertDialogPrimitive.Overlay
     className={cn(
       "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      className,
     )}
     {...props}
     ref={ref}
   />
-))
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
@@ -34,13 +34,13 @@ const AlertDialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
+        className,
       )}
       {...props}
     />
   </AlertDialogPortal>
-))
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({
   className,
@@ -49,12 +49,12 @@ const AlertDialogHeader = ({
   <div
     className={cn(
       "flex flex-col space-y-2 text-center sm:text-left",
-      className
+      className,
     )}
     {...props}
   />
-)
-AlertDialogHeader.displayName = "AlertDialogHeader"
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({
   className,
@@ -63,12 +63,12 @@ const AlertDialogFooter = ({
   <div
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      className,
     )}
     {...props}
   />
-)
-AlertDialogFooter.displayName = "AlertDialogFooter"
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
 
 const AlertDialogTitle = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Title>,
@@ -79,8 +79,8 @@ const AlertDialogTitle = React.forwardRef<
     className={cn("text-lg font-semibold", className)}
     {...props}
   />
-))
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
 
 const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
@@ -91,9 +91,9 @@ const AlertDialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
+));
 AlertDialogDescription.displayName =
-  AlertDialogPrimitive.Description.displayName
+  AlertDialogPrimitive.Description.displayName;
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
@@ -104,8 +104,8 @@ const AlertDialogAction = React.forwardRef<
     className={cn(buttonVariants(), className)}
     {...props}
   />
-))
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
@@ -116,12 +116,12 @@ const AlertDialogCancel = React.forwardRef<
     className={cn(
       buttonVariants({ variant: "outline" }),
       "mt-2 sm:mt-0",
-      className
+      className,
     )}
     {...props}
   />
-))
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
@@ -135,4 +135,4 @@ export {
   AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-}
+};

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,36 +1,36 @@
-import * as React from 'react';
-import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from '@/lib/utils';
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
         destructive:
-          'bg-destructive text-white shadow-sm hover:bg-destructive/90',
+          "bg-destructive text-white shadow-sm hover:bg-destructive/90",
         destructiveOutline:
-          'border border-destructive bg-background text-destructive shadow-sm hover:bg-destructive hover:text-white',
+          "border border-destructive bg-background text-destructive shadow-sm hover:bg-destructive hover:text-white",
         outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary:
-          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-8',
-        icon: 'h-9 w-9',
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
+      variant: "default",
+      size: "default",
     },
   },
 );
@@ -44,7 +44,7 @@ export interface ButtonProps
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,5 +1,5 @@
-import * as React from "react"
-import { cn } from "@/lib/utils"
+import * as React from "react";
+import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -9,12 +9,12 @@ const Card = React.forwardRef<
     ref={ref}
     className={cn(
       "rounded-xl border border-border bg-card text-card-foreground shadow-sm",
-      className
+      className,
     )}
     {...props}
   />
-))
-Card.displayName = "Card"
+));
+Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
@@ -25,8 +25,8 @@ const CardHeader = React.forwardRef<
     className={cn("flex flex-col space-y-1.5 p-6", className)}
     {...props}
   />
-))
-CardHeader.displayName = "CardHeader"
+));
+CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
   HTMLDivElement,
@@ -37,8 +37,8 @@ const CardTitle = React.forwardRef<
     className={cn("font-semibold leading-none tracking-tight", className)}
     {...props}
   />
-))
-CardTitle.displayName = "CardTitle"
+));
+CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<
   HTMLDivElement,
@@ -49,16 +49,16 @@ const CardDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-CardDescription.displayName = "CardDescription"
+));
+CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+));
+CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
@@ -69,7 +69,14 @@ const CardFooter = React.forwardRef<
     className={cn("flex items-center p-6 pt-0", className)}
     {...props}
   />
-))
-CardFooter.displayName = "CardFooter"
+));
+CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -18,7 +18,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-card p-6 ring-1 ring-border/50 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-card p-6 ring-1 ring-border/50 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
@@ -56,13 +56,13 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col space-y-1.5 text-center sm:text-left',
+      "flex flex-col space-y-1.5 text-center sm:text-left",
       className,
     )}
     {...props}
   />
 );
-DialogHeader.displayName = 'DialogHeader';
+DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({
   className,
@@ -70,13 +70,13 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
       className,
     )}
     {...props}
   />
 );
-DialogFooter.displayName = 'DialogFooter';
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -85,7 +85,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight',
+      "text-lg font-semibold leading-none tracking-tight",
       className,
     )}
     {...props}
@@ -99,7 +99,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { cn } from '@/lib/utils';
+import * as React from "react";
+import { cn } from "@/lib/utils";
 
 const Input = React.forwardRef<
   HTMLInputElement,
@@ -9,7 +9,7 @@ const Input = React.forwardRef<
     <input
       type={type}
       className={cn(
-        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 disabled:cursor-not-allowed disabled:opacity-50',
+        "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}
@@ -17,6 +17,6 @@ const Input = React.forwardRef<
     />
   );
 });
-Input.displayName = 'Input';
+Input.displayName = "Input";
 
 export { Input };

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,11 +1,11 @@
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
-import { cn } from "@/lib/utils"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
@@ -17,7 +17,7 @@ const Label = React.forwardRef<
     className={cn(labelVariants(), className)}
     {...props}
   />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+));
+Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label }
+export { Label };

--- a/frontend/src/hooks/useContainerStats.ts
+++ b/frontend/src/hooks/useContainerStats.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getContainerStats } from "../api/client";
+import type { ContainerStats } from "../api/types";
+
+const containerStatsKey = "containerStats";
+
+export function useContainerStats(containerId: string) {
+  return useQuery<ContainerStats, Error>({
+    queryKey: [containerStatsKey, containerId],
+    queryFn: () => getContainerStats(containerId),
+    refetchInterval: 5000, // Poll every 5 seconds
+    refetchIntervalInBackground: false, // Pause polling when window is not visible
+    enabled: !!containerId, // Only run if containerId is provided
+  });
+}

--- a/frontend/src/hooks/useContainers.ts
+++ b/frontend/src/hooks/useContainers.ts
@@ -1,10 +1,17 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getProject, getContainers, deleteProject, startContainer, stopContainer, restartContainer } from '../api/client';
-import type { Project, Container } from '../api/types';
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getProject,
+  getContainers,
+  deleteProject,
+  startContainer,
+  stopContainer,
+  restartContainer,
+} from "../api/client";
+import type { Project, Container } from "../api/types";
 
 // Query keys
-const projectsKey = 'projects';
-const containersKey = 'containers';
+const projectsKey = "projects";
+const containersKey = "containers";
 
 export function useProject(projectId: string) {
   return useQuery<Project, Error>({

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,13 +1,13 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   listProjects,
   createProject,
   deleteProject,
   validatePath,
-} from '../api/client';
-import type { CreateProjectRequest } from '../api/types';
+} from "../api/client";
+import type { CreateProjectRequest } from "../api/types";
 
-const projectsKey = 'projects';
+const projectsKey = "projects";
 
 export function useProjects() {
   return useQuery({

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
-import { ArrowLeft, FolderOpen, Trash2, AlertTriangle } from 'lucide-react';
-import { Link, useParams, useNavigate } from 'react-router';
-import { toast } from 'sonner';
+import { useState } from "react";
+import { ArrowLeft, FolderOpen, Trash2, AlertTriangle } from "lucide-react";
+import { Link, useParams, useNavigate } from "react-router";
+import { toast } from "sonner";
 import {
   useProject,
   useContainers,
@@ -9,13 +9,13 @@ import {
   useStartContainer,
   useStopContainer,
   useRestartContainer,
-} from '../hooks/useContainers';
-import { ContainerTable } from '../components/containers/ContainerTable';
+} from "../hooks/useContainers";
+import { ContainerTable } from "../components/containers/ContainerTable";
 import {
   ContainerTableSkeleton,
   ProjectDetailHeaderSkeleton,
-} from '../components/skeletons/ContainerSkeletons';
-import { Button } from '../components/ui/button';
+} from "../components/skeletons/ContainerSkeletons";
+import { Button } from "../components/ui/button";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -25,7 +25,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '../components/ui/alert-dialog';
+} from "../components/ui/alert-dialog";
 
 export function ProjectDetailPage() {
   const { projectId } = useParams<{ projectId: string }>();
@@ -36,14 +36,14 @@ export function ProjectDetailPage() {
     data: project,
     isLoading: projectLoading,
     error: projectError,
-  } = useProject(projectId ?? '');
+  } = useProject(projectId ?? "");
   const { data: containers, isLoading: containersLoading } = useContainers(
-    projectId ?? '',
+    projectId ?? "",
   );
   const deleteProject = useDeleteProject();
-  const startContainer = useStartContainer(projectId ?? '');
-  const stopContainer = useStopContainer(projectId ?? '');
-  const restartContainer = useRestartContainer(projectId ?? '');
+  const startContainer = useStartContainer(projectId ?? "");
+  const stopContainer = useStopContainer(projectId ?? "");
+  const restartContainer = useRestartContainer(projectId ?? "");
 
   if (!projectId) {
     return (
@@ -56,12 +56,12 @@ export function ProjectDetailPage() {
   const handleDeleteProject = async () => {
     try {
       await deleteProject.mutateAsync(projectId);
-      toast.success('Project removed successfully');
+      toast.success("Project removed successfully");
       setShowDeleteConfirm(false);
-      navigate('/projects');
+      navigate("/projects");
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : 'Failed to remove project';
+        err instanceof Error ? err.message : "Failed to remove project";
       toast.error(message);
     }
   };
@@ -69,10 +69,10 @@ export function ProjectDetailPage() {
   const handleStartContainer = async (containerId: string) => {
     try {
       await startContainer.mutateAsync(containerId);
-      toast.success('Container started successfully');
+      toast.success("Container started successfully");
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : 'Failed to start container';
+        err instanceof Error ? err.message : "Failed to start container";
       toast.error(message);
     }
   };
@@ -80,10 +80,10 @@ export function ProjectDetailPage() {
   const handleStopContainer = async (containerId: string) => {
     try {
       await stopContainer.mutateAsync(containerId);
-      toast.success('Container stopped successfully');
+      toast.success("Container stopped successfully");
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : 'Failed to stop container';
+        err instanceof Error ? err.message : "Failed to stop container";
       toast.error(message);
     }
   };
@@ -91,10 +91,10 @@ export function ProjectDetailPage() {
   const handleRestartContainer = async (containerId: string) => {
     try {
       await restartContainer.mutateAsync(containerId);
-      toast.success('Container restarted successfully');
+      toast.success("Container restarted successfully");
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : 'Failed to restart container';
+        err instanceof Error ? err.message : "Failed to restart container";
       toast.error(message);
     }
   };
@@ -127,14 +127,14 @@ export function ProjectDetailPage() {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="text-destructive">
-          {projectError?.message || 'Failed to load project'}
+          {projectError?.message || "Failed to load project"}
         </div>
       </div>
     );
   }
 
   const runningCount =
-    containers?.filter(c => c.state === 'running').length ?? 0;
+    containers?.filter((c) => c.state === "running").length ?? 0;
   const totalCount = containers?.length ?? 0;
 
   return (
@@ -166,7 +166,7 @@ export function ProjectDetailPage() {
             </div>
             <p className="mt-1 text-sm text-muted-foreground">
               {project.compose_file} • {totalCount} container
-              {totalCount !== 1 ? 's' : ''}
+              {totalCount !== 1 ? "s" : ""}
             </p>
           </div>
 
@@ -207,8 +207,8 @@ export function ProjectDetailPage() {
           <h2 className="text-lg font-medium text-foreground">Containers</h2>
           <p className="text-sm text-muted-foreground">
             {containersLoading
-              ? 'Loading containers...'
-              : `${totalCount} container${totalCount !== 1 ? 's' : ''}`}
+              ? "Loading containers..."
+              : `${totalCount} container${totalCount !== 1 ? "s" : ""}`}
           </p>
         </div>
         <div className="p-6">
@@ -228,7 +228,7 @@ export function ProjectDetailPage() {
 
       <AlertDialog
         open={showDeleteConfirm}
-        onOpenChange={open => !open && setShowDeleteConfirm(false)}
+        onOpenChange={(open) => !open && setShowDeleteConfirm(false)}
       >
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -288,6 +288,32 @@ func (h *Handler) RestartContainer(w http.ResponseWriter, r *http.Request) {
 	h.sendJSON(w, http.StatusOK, map[string]string{"message": "Container restarted"})
 }
 
+func (h *Handler) GetContainerStats(w http.ResponseWriter, r *http.Request) {
+	// Extract container ID from path: /api/containers/:id/stats
+	path := r.URL.Path
+	if !strings.HasSuffix(path, "/stats") {
+		h.sendError(w, http.StatusBadRequest, "INVALID_PATH", "Invalid path")
+		return
+	}
+
+	id := path[len("/api/containers/") : len(path)-len("/stats")]
+
+	stats, err := h.dockerClient.GetStats(r.Context(), id)
+	if err != nil {
+		h.sendError(w, http.StatusInternalServerError, "DOCKER_ERROR", fmt.Sprintf("Failed to get container stats: %v", err))
+		return
+	}
+
+	// Convert to API type
+	result := ContainerStats{
+		CPUPercentage:    stats.CPUPercentage,
+		MemoryPercentage: stats.MemoryPercentage,
+		PIDs:             stats.PIDs,
+	}
+
+	h.sendJSON(w, http.StatusOK, result)
+}
+
 func (h *Handler) sendJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -79,6 +79,12 @@ func SetupRoutes(mux *http.ServeMux, store *store.Store, dockerClient *docker.Cl
 			return
 		}
 
+		// Handle /api/containers/:id/stats
+		if strings.HasSuffix(path, "/stats") && r.Method == http.MethodGet {
+			handler.GetContainerStats(w, r)
+			return
+		}
+
 		w.WriteHeader(http.StatusNotFound)
 	})
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -53,3 +53,10 @@ type ValidatePathResponse struct {
 	Name        string `json:"name,omitempty"`
 	Error       string `json:"error,omitempty"`
 }
+
+// ContainerStats represents resource usage statistics for a container
+type ContainerStats struct {
+	CPUPercentage    float64 `json:"cpu_percentage"`
+	MemoryPercentage float64 `json:"memory_percentage"`
+	PIDs             int     `json:"pids"`
+}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -13,14 +14,14 @@ import (
 
 // Container represents a Docker container with compose-related metadata
 type Container struct {
-	ID       string        `json:"id"`
-	Name     string        `json:"name"`
-	Project  string        `json:"project"`
-	Service  string        `json:"service"`
-	Image    string        `json:"image"`
-	Status   string        `json:"status"`
-	State    string        `json:"state"`
-	Ports    []PortMapping `json:"ports"`
+	ID      string        `json:"id"`
+	Name    string        `json:"name"`
+	Project string        `json:"project"`
+	Service string        `json:"service"`
+	Image   string        `json:"image"`
+	Status  string        `json:"status"`
+	State   string        `json:"state"`
+	Ports   []PortMapping `json:"ports"`
 }
 
 // PortMapping represents a port mapping between host and container
@@ -60,7 +61,7 @@ func (c *Client) ListContainersByProject(ctx context.Context, projectName string
 	// Filter containers by compose project label
 	filterArgs := filters.NewArgs()
 	filterArgs.Add("label", fmt.Sprintf("com.docker.compose.project=%s", projectName))
-	
+
 	containers, err := c.cli.ContainerList(ctx, container.ListOptions{
 		All:     true,
 		Filters: filterArgs,
@@ -146,6 +147,50 @@ func (c *Client) GetContainer(ctx context.Context, id string) (*Container, error
 	}
 
 	return container, nil
+}
+
+// ContainerStats represents resource usage statistics for a container
+type ContainerStats struct {
+	CPUPercentage    float64 `json:"cpu_percentage"`
+	MemoryPercentage float64 `json:"memory_percentage"`
+	PIDs             int     `json:"pids"`
+}
+
+// GetStats returns resource usage statistics for a container
+func (c *Client) GetStats(ctx context.Context, containerID string) (*ContainerStats, error) {
+	stats, err := c.cli.ContainerStats(ctx, containerID, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container stats: %w", err)
+	}
+	defer stats.Body.Close()
+
+	var statsJSON types.StatsJSON
+	if err := json.NewDecoder(stats.Body).Decode(&statsJSON); err != nil {
+		return nil, fmt.Errorf("failed to decode stats: %w", err)
+	}
+
+	// Calculate CPU percentage
+	cpuDelta := float64(statsJSON.CPUStats.CPUUsage.TotalUsage - statsJSON.PreCPUStats.CPUUsage.TotalUsage)
+	systemDelta := float64(statsJSON.CPUStats.SystemUsage - statsJSON.PreCPUStats.SystemUsage)
+	cpuPercentage := 0.0
+	if systemDelta > 0 && cpuDelta > 0 {
+		cpuPercentage = (cpuDelta / systemDelta) * float64(len(statsJSON.CPUStats.CPUUsage.PercpuUsage)) * 100.0
+	}
+
+	// Calculate memory percentage
+	memoryPercentage := 0.0
+	if statsJSON.MemoryStats.Limit > 0 {
+		memoryPercentage = float64(statsJSON.MemoryStats.Usage) / float64(statsJSON.MemoryStats.Limit) * 100.0
+	}
+
+	// Get PID count
+	pids := int(statsJSON.PidsStats.Current)
+
+	return &ContainerStats{
+		CPUPercentage:    cpuPercentage,
+		MemoryPercentage: memoryPercentage,
+		PIDs:             pids,
+	}, nil
 }
 
 // StartContainer starts a container

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -1,0 +1,205 @@
+package docker
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCalculateCPUPercentage(t *testing.T) {
+	tests := []struct {
+		name            string
+		cpuDelta        float64
+		systemDelta     float64
+		percpuCount     int
+		expectedPercent float64
+	}{
+		{
+			name:            "normal usage",
+			cpuDelta:        100000000,
+			systemDelta:     100000000,
+			percpuCount:     2,
+			expectedPercent: 200.0,
+		},
+		{
+			name:            "zero system delta",
+			cpuDelta:        100000000,
+			systemDelta:     0,
+			percpuCount:     2,
+			expectedPercent: 0.0,
+		},
+		{
+			name:            "zero cpu delta",
+			cpuDelta:        0,
+			systemDelta:     100000000,
+			percpuCount:     2,
+			expectedPercent: 0.0,
+		},
+		{
+			name:            "50% single core",
+			cpuDelta:        50000000,
+			systemDelta:     100000000,
+			percpuCount:     1,
+			expectedPercent: 50.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpuPercentage := 0.0
+			if tt.systemDelta > 0 && tt.cpuDelta > 0 {
+				cpuPercentage = (tt.cpuDelta / tt.systemDelta) * float64(tt.percpuCount) * 100.0
+			}
+
+			if cpuPercentage != tt.expectedPercent {
+				t.Errorf("Expected CPU percentage %.2f, got %.2f", tt.expectedPercent, cpuPercentage)
+			}
+		})
+	}
+}
+
+func TestCalculateMemoryPercentage(t *testing.T) {
+	tests := []struct {
+		name            string
+		usage           uint64
+		limit           uint64
+		expectedPercent float64
+	}{
+		{
+			name:            "50% usage",
+			usage:           512 * 1024 * 1024,  // 512MB
+			limit:           1024 * 1024 * 1024, // 1GB
+			expectedPercent: 50.0,
+		},
+		{
+			name:            "zero limit",
+			usage:           512 * 1024 * 1024,
+			limit:           0,
+			expectedPercent: 0.0,
+		},
+		{
+			name:            "zero usage",
+			usage:           0,
+			limit:           1024 * 1024 * 1024,
+			expectedPercent: 0.0,
+		},
+		{
+			name:            "25% usage",
+			usage:           256 * 1024 * 1024,  // 256MB
+			limit:           1024 * 1024 * 1024, // 1GB
+			expectedPercent: 25.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memoryPercentage := 0.0
+			if tt.limit > 0 {
+				memoryPercentage = float64(tt.usage) / float64(tt.limit) * 100.0
+			}
+
+			if memoryPercentage != tt.expectedPercent {
+				t.Errorf("Expected memory percentage %.2f, got %.2f", tt.expectedPercent, memoryPercentage)
+			}
+		})
+	}
+}
+
+func TestContainerStats_Struct(t *testing.T) {
+	stats := ContainerStats{
+		CPUPercentage:    25.5,
+		MemoryPercentage: 50.0,
+		PIDs:             10,
+	}
+
+	if stats.CPUPercentage != 25.5 {
+		t.Errorf("Expected CPU percentage 25.5, got %.2f", stats.CPUPercentage)
+	}
+	if stats.MemoryPercentage != 50.0 {
+		t.Errorf("Expected memory percentage 50.0, got %.2f", stats.MemoryPercentage)
+	}
+	if stats.PIDs != 10 {
+		t.Errorf("Expected PIDs 10, got %d", stats.PIDs)
+	}
+}
+
+func TestContainerStats_JSONSerialization(t *testing.T) {
+	stats := ContainerStats{
+		CPUPercentage:    25.5,
+		MemoryPercentage: 50.0,
+		PIDs:             10,
+	}
+
+	data, err := json.Marshal(stats)
+	if err != nil {
+		t.Fatalf("Failed to marshal ContainerStats: %v", err)
+	}
+
+	expected := `{"cpu_percentage":25.5,"memory_percentage":50,"pids":10}`
+	if string(data) != expected {
+		t.Errorf("Expected JSON %s, got %s", expected, string(data))
+	}
+
+	// Test deserialization
+	var decoded ContainerStats
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal ContainerStats: %v", err)
+	}
+
+	if decoded.CPUPercentage != stats.CPUPercentage {
+		t.Errorf("Expected CPU percentage %.2f, got %.2f", stats.CPUPercentage, decoded.CPUPercentage)
+	}
+	if decoded.MemoryPercentage != stats.MemoryPercentage {
+		t.Errorf("Expected memory percentage %.2f, got %.2f", stats.MemoryPercentage, decoded.MemoryPercentage)
+	}
+	if decoded.PIDs != stats.PIDs {
+		t.Errorf("Expected PIDs %d, got %d", stats.PIDs, decoded.PIDs)
+	}
+}
+
+// TestContainerStats_ZeroValues tests the behavior with zero/empty values
+func TestContainerStats_ZeroValues(t *testing.T) {
+	stats := ContainerStats{
+		CPUPercentage:    0.0,
+		MemoryPercentage: 0.0,
+		PIDs:             0,
+	}
+
+	data, err := json.Marshal(stats)
+	if err != nil {
+		t.Fatalf("Failed to marshal zero ContainerStats: %v", err)
+	}
+
+	expected := `{"cpu_percentage":0,"memory_percentage":0,"pids":0}`
+	if string(data) != expected {
+		t.Errorf("Expected JSON %s, got %s", expected, string(data))
+	}
+}
+
+// TestContainerStats_HighValues tests the behavior with high values
+func TestContainerStats_HighValues(t *testing.T) {
+	stats := ContainerStats{
+		CPUPercentage:    400.0,
+		MemoryPercentage: 99.9,
+		PIDs:             32768,
+	}
+
+	data, err := json.Marshal(stats)
+	if err != nil {
+		t.Fatalf("Failed to marshal high value ContainerStats: %v", err)
+	}
+
+	var decoded ContainerStats
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal ContainerStats: %v", err)
+	}
+
+	if decoded.CPUPercentage != stats.CPUPercentage {
+		t.Errorf("Expected CPU percentage %.2f, got %.2f", stats.CPUPercentage, decoded.CPUPercentage)
+	}
+	if decoded.MemoryPercentage != stats.MemoryPercentage {
+		t.Errorf("Expected memory percentage %.2f, got %.2f", stats.MemoryPercentage, decoded.MemoryPercentage)
+	}
+	if decoded.PIDs != stats.PIDs {
+		t.Errorf("Expected PIDs %d, got %d", stats.PIDs, decoded.PIDs)
+	}
+}


### PR DESCRIPTION
Add real-time resource metrics displayed inline in the container table:
- Docker client GetStats() method returning CPU%, memory%, and PIDs
- Backend API endpoint GET /api/containers/:id/stats
- Frontend useContainerStats hook with 5-second polling
- ContainerTable displays CPU%, memory%, and PIDs columns
- Unit tests for stats calculation logic

Closes #8